### PR TITLE
Use std::isnan instead of isnan in global ns

### DIFF
--- a/inc/base/float_util.h
+++ b/inc/base/float_util.h
@@ -25,7 +25,7 @@ inline bool IsFinite(const Float& number) {
 template <typename Float>
 inline bool IsNaN(const Float& number) {
 #if defined(OS_POSIX)
-  return isnan(number) != 0;
+  return std::isnan(number) != 0;
 #elif defined(OS_WIN)
   return _isnan(number) != 0;
 #endif


### PR DESCRIPTION
This is needed to make it compile on my machine (Ubuntu 16.04, gcc 5.4.0).

As far as I can tell the global version of `isnan` is [from a C header and shouldn't really be used in C++ anymore](https://bfff9e8-dot-chromiumcodereview-hr.appspot.com/1853263002/).