### PR TITLE
Fix not being able to click on svg elements 

### DIFF
--- a/src/third_party/webdriver/atoms.cc
+++ b/src/third_party/webdriver/atoms.cc
@@ -2984,7 +2984,7 @@ const char* const IS_ELEMENT_CLICKABLE[] = {
     "ckable:a};b&&(d.message=b);return d}var a=h.ownerDocument.elementFromPo",
     "int(d.x,d.y);if(a==h)return g(!0);var l=\"(\"+d.x+\", \"+d.y+\")\";if(n",
     "ull==a)return g(!1,\"Element is not clickable at point \"+l);var b=a.ou",
-    "terHTML;if(a.hasChildNodes())var m=a.innerHTML,n=b.length-m.length-(\"<",
+    "terHTML;if(a.hasChildNodes()&&b)var m=a.innerHTML,n=b.length-m.length-(\"<",
     "/\"+a.tagName+\">\").length,b=b.substring(0,n)+\"...\"+b.substring(n+m.",
     "length);for(a=a.parentNode;a;){if(a==h)return g(!0,\"Element's descenda",
     "nt would receive the click. Consider clicking the descendant instead. D",


### PR DESCRIPTION
Currently attempting to click on an svg element gives the error:

```
Message: isElementClickable execution failed;
 undefined is not an object (evaluating 'b.length')
```

This is because in the `IS_ELEMENT_CLICKABLE` atom the Javascript code assumes that the svg element has the `outerHTML` property but it doesn't. The outerHTML information is only used for improved error reporting so it should be safe to ignore it for svg elements.

I guess we shouldn't be hacking on compiled javascript output like this, so if you can point me towards some instructions for making changes and re-compiling I'm happy to do that. Also are there any tests for this stuff?

P.S. it seems unlikely that this will be fixed upstream, there's [a long abandoned bug report](https://bugs.chromium.org/p/chromedriver/issues/detail?id=427) with no activity, and it appears that modern browsers [support calling `outerHTML` on svg elements](http://stackoverflow.com/a/20567416/874671).