### PR TITLE
Add QTabWidget and QTreeWidget GetElementText() support

### DIFF
--- a/src/webdriver/extension_qt/widget_view_executor.cc
+++ b/src/webdriver/extension_qt/widget_view_executor.cc
@@ -56,6 +56,7 @@
 #include <QtWidgets/QAction>
 #include <QtWidgets/QTreeWidget>
 #include <QtWidgets/QTreeWidgetItem>
+#include <QtWidgets/QTabWidget>
 #if (1 == WD_ENABLE_PLAYER)
 #include <QtMultimediaWidgets/QVideoWidget>
 #include <QtMultimedia/QMediaPlayer>
@@ -78,6 +79,7 @@
 #include <QtGui/QAction>
 #include <QtGui/QTreeWidget>
 #include <QtGui/QTreeWidgetItem>
+#include <QtGui/QTabWidget>
 #endif
 
 #include "third_party/pugixml/pugixml.hpp"
@@ -858,6 +860,17 @@ void QWidgetViewCmdExecutor::GetElementText(const ElementId& element, std::strin
                 list.append(currentItem->text(col));
             }
             *element_text = list.join("\n").toStdString();
+            return;
+        }
+    }
+    
+    QTabWidget * tabWidget = qobject_cast<QTabWidget*>(pElement);
+    if (NULL != tabWidget) {
+        int currentIndex = tabWidget->currentIndex();
+        // if currentIndex == -1, then it means that there is no current widget (it's the default value)
+        if (currentIndex != -1) {
+            QString currentTabText = tabWidget->tabText(currentIndex);
+            *element_text = currentTabText.toStdString();
             return;
         }
     }

--- a/src/webdriver/extension_qt/widget_view_executor.cc
+++ b/src/webdriver/extension_qt/widget_view_executor.cc
@@ -54,6 +54,8 @@
 #include <QtWidgets/QProgressBar>
 #include <QtWidgets/QListView>
 #include <QtWidgets/QAction>
+#include <QtWidgets/QTreeWidget>
+#include <QtWidgets/QTreeWidgetItem>
 #if (1 == WD_ENABLE_PLAYER)
 #include <QtMultimediaWidgets/QVideoWidget>
 #include <QtMultimedia/QMediaPlayer>
@@ -74,6 +76,8 @@
 #include <QtGui/QProgressBar>
 #include <QtGui/QListView>
 #include <QtGui/QAction>
+#include <QtGui/QTreeWidget>
+#include <QtGui/QTreeWidgetItem>
 #endif
 
 #include "third_party/pugixml/pugixml.hpp"
@@ -841,6 +845,21 @@ void QWidgetViewCmdExecutor::GetElementText(const ElementId& element, std::strin
         }
         *element_text = list.join("\n").toStdString();
         return;
+    }
+
+    QTreeWidget * tree = qobject_cast<QTreeWidget*>(pElement);
+    if (NULL != tree) {
+        QTreeWidgetItem * currentItem = tree->currentItem();
+        // if NULL, then no item is currently selected in the tree
+        if(NULL != currentItem) {
+            QStringList list;
+            for( int col = 0; col < currentItem->columnCount(); ++col ) 
+            {
+                list.append(currentItem->text(col));
+            }
+            *element_text = list.join("\n").toStdString();
+            return;
+        }
     }
 
     QVariant textValue = pElement->property("text");


### PR DESCRIPTION
Hi,

This pull request adds support of the GetElementText() function for the QTabWidget and QTreeWidget classes. 

The new behaviour is:

* In the case of a QTabWidget, we return the text of the current tab
* In the case of a QTreeWidget, get return the text of the current selected item in the tree.

I've been using these changes for 2 weeks without any issues, but if I forgot something please tell and i'll try to fix it.

Raphaël